### PR TITLE
Add -i --includes option extending the paths to search for jinja templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ nosetests.xml
 
 .pytest_cache
 dist/
+env/
+*.iml

--- a/README.md
+++ b/README.md
@@ -17,15 +17,20 @@ Usage: jinja2 [options] <input template> <input data>
 Options:
   --version             show program's version number and exit
   -h, --help            show this help message and exit
-  --format=FORMAT       format of input variables: auto, ini, json,
+  --format=FORMAT       format of input variables: auto, env, ini, json,
                         querystring, yaml, yml
   -e EXTENSIONS, --extension=EXTENSIONS
                         extra jinja2 extensions to load
+  -I INCLUDES, --includes=INCLUDES
+                        extra jinja2 template directory to search for
+                        (included) templates
   -D key=value          Define template variable in the form of key=value
   -s SECTION, --section=SECTION
                         Use only this section from the configuration
   --strict              Disallow undefined variables to be used within the
                         template
+  -o FILE, --outfile=FILE
+                        File to use for output. Default is stdout.
 ```
 
 ## Optional YAML support

--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -212,11 +212,11 @@ formats = {
 }
 
 
-def render(template_path, data, extensions, strict=False):
+def render(template_path, data, extensions, strict=False, includes=[]):
     from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
     env = Environment(
-        loader=FileSystemLoader(os.path.dirname(template_path)),
+        loader=FileSystemLoader([os.path.dirname(template_path)] + includes),
         extensions=extensions,
         keep_trailing_newline=True,
     )
@@ -311,7 +311,7 @@ def cli(opts, args):
 
         out = codecs.getwriter("utf8")(out)
 
-    out.write(render(template_path, data, extensions, opts.strict))
+    out.write(render(template_path, data, extensions, opts.strict, includes=opts.includes))
     out.flush()
     return 0
 
@@ -377,6 +377,13 @@ def main():
         dest="extensions",
         action="append",
         default=["do", "with_", "autoescape", "loopcontrols"],
+    )
+    parser.add_option(
+        "-I",
+        "--includes",
+        help="extra jinja2 template directory to search for (included) templates",
+        dest="includes",
+        action="append",
     )
     parser.add_option(
         "-D",


### PR DESCRIPTION
This is useful for reuse when a set of shared templates are maintained in another directory
by  using {% include 'lib/header.j2' %} style includes.